### PR TITLE
fix: use github email address in ci

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,7 +22,7 @@ jobs:
     
     - name: Setup Git
       run: |
-        git config --global user.email "calvin@snicco.de"
+        git config --global user.email "calvin@snicco.io"
         git config --global user.name "Calvin Alkan"
 
     - name: Run update script


### PR DESCRIPTION
Please see unclickable authors: https://github.com/snicco/php-scoper-wordpress-excludes/commits/master